### PR TITLE
Fix nested transaction logging and enable logging

### DIFF
--- a/src/Fg.DbUtils.Dapper.IntegrationTests/DapperTransactionTests.cs
+++ b/src/Fg.DbUtils.Dapper.IntegrationTests/DapperTransactionTests.cs
@@ -73,19 +73,14 @@ namespace Fg.DbUtils.Dapper.IntegrationTests
             Assert.Equal(7, result);
         }
 
-        [Fact(Skip="no longer relevant")]
-        public void CommitOnlyHappensOnOuterTransaction()
+        [Fact]
+        public void BeginTransaction_Throws_WhenTransactionAlreadyActive()
         {
             var dbSession = new DbSession(_connection);
 
             dbSession.BeginTransaction();
-            dbSession.BeginTransaction();
-            Assert.True(dbSession.IsInTransaction);
 
-            dbSession.CommitTransaction();
-            Assert.True(dbSession.IsInTransaction, "A commit was called on the inner transaction, we cannot commit yet");
-            dbSession.CommitTransaction();
-            Assert.False(dbSession.IsInTransaction, "A commit was called on the outer transaction, we should now no longer have an active transaction");
+            Assert.Throws<InvalidOperationException>(() => dbSession.BeginTransaction());
         }
 
         /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>

--- a/src/Fg.DbUtils.Dapper.IntegrationTests/DapperTransactionTests.cs
+++ b/src/Fg.DbUtils.Dapper.IntegrationTests/DapperTransactionTests.cs
@@ -73,7 +73,7 @@ namespace Fg.DbUtils.Dapper.IntegrationTests
             Assert.Equal(7, result);
         }
 
-        [Fact]
+        [Fact(Skip="no longer relevant")]
         public void CommitOnlyHappensOnOuterTransaction()
         {
             var dbSession = new DbSession(_connection);

--- a/src/Fg.DbUtils.Dapper.IntegrationTests/DapperTransactionTests.cs
+++ b/src/Fg.DbUtils.Dapper.IntegrationTests/DapperTransactionTests.cs
@@ -73,6 +73,21 @@ namespace Fg.DbUtils.Dapper.IntegrationTests
             Assert.Equal(7, result);
         }
 
+        [Fact]
+        public void CommitOnlyHappensOnOuterTransaction()
+        {
+            var dbSession = new DbSession(_connection);
+
+            dbSession.BeginTransaction();
+            dbSession.BeginTransaction();
+            Assert.True(dbSession.IsInTransaction);
+
+            dbSession.CommitTransaction();
+            Assert.True(dbSession.IsInTransaction, "A commit was called on the inner transaction, we cannot commit yet");
+            dbSession.CommitTransaction();
+            Assert.False(dbSession.IsInTransaction, "A commit was called on the outer transaction, we should now no longer have an active transaction");
+        }
+
         /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
         public void Dispose()
         {

--- a/src/Fg.DbUtils.Dapper.IntegrationTests/DbSessionFactoryTests.cs
+++ b/src/Fg.DbUtils.Dapper.IntegrationTests/DbSessionFactoryTests.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Fg.DbUtils.Dapper.IntegrationTests
+{
+    public class DbSessionFactoryTests
+    {
+        [Fact]
+        public void DbSessionHasNullLogger_When_LoggerFactoryIsNotSpecified()
+        {
+            DbSessionFactory factory = new DbSessionFactory(() => SqliteDatabase.OpenDatabase());
+
+            using (var session = factory.CreateDbSession())
+            {
+                Assert.Equal(NullLogger<IDbSession>.Instance, session.Logger);
+            }
+        }
+    }
+}

--- a/src/Fg.DbUtils/DbSession.cs
+++ b/src/Fg.DbUtils/DbSession.cs
@@ -139,8 +139,9 @@ namespace Fg.DbUtils
             }
 
             Transaction?.Rollback();
-            _nestedTransactionCount = 0;
+            Transaction?.Dispose();
             Transaction = null;
+            _nestedTransactionCount = 0;
         }
 
         /// <summary>Changes the current database for an open Connection object.</summary>
@@ -162,10 +163,9 @@ namespace Fg.DbUtils
         /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
         public void Dispose()
         {
-            Transaction?.Dispose();
+            _logger.LogInformation("Disposing DbSession");
+            Close();
             _connection?.Dispose();
-
-            Transaction = null;
         }
 
         /// <summary>Gets the time to wait while trying to establish a connection before terminating the attempt and generating an error.</summary>

--- a/src/Fg.DbUtils/DbSession.cs
+++ b/src/Fg.DbUtils/DbSession.cs
@@ -124,18 +124,19 @@ namespace Fg.DbUtils
         {
             if (IsInTransaction)
             {
-                _nestedTransactionCount++;
-                using (_logger.BeginScope(new Dictionary<string, object>() { ["NestedTransactionCount"] = _nestedTransactionCount }))
-                {
-                    _logger.LogDebug($"BeginTransaction: transaction is already active - NestedTransactionCount incremented ({_nestedTransactionCount})");
-                }
+                throw new InvalidOperationException("DbSession already has an active transaction");
+                //_nestedTransactionCount++;
+                //using (_logger.BeginScope(new Dictionary<string, object>() { ["NestedTransactionCount"] = _nestedTransactionCount }))
+                //{
+                //    _logger.LogDebug($"BeginTransaction: transaction is already active - NestedTransactionCount incremented ({_nestedTransactionCount})");
+                //}
 
-                if (_nestedTransactionCount > 1)
-                {
-                    _logger.LogDebug("NestedTransaction > 1 - stacktrace: " + Environment.StackTrace);
-                }
+                //if (_nestedTransactionCount > 1)
+                //{
+                //    _logger.LogDebug("NestedTransaction > 1 - stacktrace: " + Environment.StackTrace);
+                //}
 
-                return Transaction;
+                //return Transaction;
             }
 
             Transaction = _connection.BeginTransaction(isolationLevel);
@@ -160,21 +161,21 @@ namespace Fg.DbUtils
                 return;
             }
 
-            if (_nestedTransactionCount == 0)
-            {
-                Transaction.Commit();
-                Transaction.Dispose();
-                Transaction = null;
-                _logger.LogDebug("CommitTransaction: transaction committed");
-            }
-            else
-            {
-                _nestedTransactionCount--;
-                using (_logger.BeginScope(new Dictionary<string, object>() { ["NestedTransactionCount"] = _nestedTransactionCount }))
-                {
-                    _logger.LogDebug($"CommitTransaction: nested transaction count decremented ({_nestedTransactionCount})");
-                }
-            }
+            //if (_nestedTransactionCount == 0)
+            //{
+            Transaction.Commit();
+            Transaction.Dispose();
+            Transaction = null;
+            _logger.LogDebug("CommitTransaction: transaction committed");
+            //}
+            //else
+            //{
+            //    _nestedTransactionCount--;
+            //    using (_logger.BeginScope(new Dictionary<string, object>() { ["NestedTransactionCount"] = _nestedTransactionCount }))
+            //    {
+            //        _logger.LogDebug($"CommitTransaction: nested transaction count decremented ({_nestedTransactionCount})");
+            //    }
+            //}
         }
 
         /// <summary>

--- a/src/Fg.DbUtils/DbSession.cs
+++ b/src/Fg.DbUtils/DbSession.cs
@@ -92,7 +92,7 @@ namespace Fg.DbUtils
                 _nestedTransactionCount++;
                 using (_logger.BeginScope(new Dictionary<string, object>() { ["NestedTransactionCount"] = _nestedTransactionCount }))
                 {
-                    _logger.LogInformation("BeginTransaction: transaction is already active");
+                    _logger.LogDebug("BeginTransaction: transaction is already active - NestedTransactionCount incremented");
                 }
                 return Transaction;
             }
@@ -124,7 +124,7 @@ namespace Fg.DbUtils
                 _nestedTransactionCount--;
                 using (_logger.BeginScope(new Dictionary<string, object>() { ["NestedTransactionCount"] = _nestedTransactionCount }))
                 {
-                    _logger.LogInformation("CommitTransaction: nested transaction count decremented");
+                    _logger.LogDebug("CommitTransaction: nested transaction count decremented");
                 }
             }
         }
@@ -164,7 +164,7 @@ namespace Fg.DbUtils
         /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
         public void Dispose()
         {
-            _logger.LogInformation("Disposing DbSession");
+            _logger.LogDebug("Disposing DbSession");
             Close();
             _connection?.Dispose();
         }

--- a/src/Fg.DbUtils/DbSession.cs
+++ b/src/Fg.DbUtils/DbSession.cs
@@ -120,8 +120,6 @@ namespace Fg.DbUtils
         {
             if (IsInTransaction)
             {
-                DbTransaction x;
-
                 _nestedTransactionCount++;
                 using (_logger.BeginScope(new Dictionary<string, object>() { ["NestedTransactionCount"] = _nestedTransactionCount }))
                 {

--- a/src/Fg.DbUtils/DbSession.cs
+++ b/src/Fg.DbUtils/DbSession.cs
@@ -140,11 +140,13 @@ namespace Fg.DbUtils
 
             Transaction = _connection.BeginTransaction(isolationLevel);
 
+
             if (_nestedTransactionCount != 0)
             {
                 _logger.LogDebug($"NesteTransaction is {_nestedTransactionCount} on starting transaction");
             }
 
+            _nestedTransactionCount = 0;
             return Transaction;
         }
 

--- a/src/Fg.DbUtils/DbSession.cs
+++ b/src/Fg.DbUtils/DbSession.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
 using System.Data;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -89,6 +90,10 @@ namespace Fg.DbUtils
             if (IsInTransaction)
             {
                 _nestedTransactionCount++;
+                using (_logger.BeginScope(new Dictionary<string, object>() { ["NestedTransactionCount"] = _nestedTransactionCount }))
+                {
+                    _logger.LogInformation("BeginTransaction: transaction is already active");
+                }
                 return Transaction;
             }
 
@@ -111,10 +116,15 @@ namespace Fg.DbUtils
             {
                 Transaction?.Commit();
                 Transaction = null;
+                _logger.LogDebug("CommitTransaction: transaction committed");
             }
             else
             {
                 _nestedTransactionCount--;
+                using (_logger.BeginScope(new Dictionary<string, object>() { ["NestedTransactionCount"] = _nestedTransactionCount }))
+                {
+                    _logger.LogInformation("CommitTransaction: nested transaction count decremented");
+                }
             }
         }
 

--- a/src/Fg.DbUtils/DbSession.cs
+++ b/src/Fg.DbUtils/DbSession.cs
@@ -65,7 +65,7 @@ namespace Fg.DbUtils
         public IDbCommand CreateCommand()
         {
             var command = _connection.CreateCommand();
-            //if (IsInTransaction)
+            if (IsInTransaction)
             {
                 command.Transaction = Transaction;
             }

--- a/src/Fg.DbUtils/DbSession.cs
+++ b/src/Fg.DbUtils/DbSession.cs
@@ -54,7 +54,7 @@ namespace Fg.DbUtils
         /// <summary>Opens a database connection with the settings specified by the ConnectionString property of the provider-specific Connection object.</summary>
         public void Open()
         {
-            if (_connection.State == ConnectionState.Closed)
+            if (_connection.State != ConnectionState.Open)
             {
                 _connection.Open();
             }

--- a/src/Fg.DbUtils/DbSession.cs
+++ b/src/Fg.DbUtils/DbSession.cs
@@ -110,6 +110,7 @@ namespace Fg.DbUtils
             }
 
             Transaction?.Rollback();
+            _nestedTransactionCount = 0;
             Transaction = null;
         }
 
@@ -125,6 +126,8 @@ namespace Fg.DbUtils
         {
             Transaction?.Rollback();
             _connection.Close();
+
+            Transaction = null;
         }
 
         /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
@@ -132,6 +135,8 @@ namespace Fg.DbUtils
         {
             Transaction?.Dispose();
             _connection?.Dispose();
+
+            Transaction = null;
         }
 
         /// <summary>Gets the time to wait while trying to establish a connection before terminating the attempt and generating an error.</summary>

--- a/src/Fg.DbUtils/DbSession.cs
+++ b/src/Fg.DbUtils/DbSession.cs
@@ -1,17 +1,30 @@
-﻿using System.Data;
+﻿using Microsoft.Extensions.Logging;
+using System.Data;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Fg.DbUtils
 {
     public class DbSession : IDbSession
     {
         private readonly IDbConnection _connection;
+        private readonly ILogger<IDbSession> _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DbSession"/> class.
         /// </summary>
-        public DbSession(IDbConnection connection)
+        public DbSession(IDbConnection connection) : this(connection, NullLogger<IDbSession>.Instance)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DbSession"/> class.
+        /// </summary>
+        /// <param name="connection">The <see cref="IDbConnection"/> that must be used to connect to the database.</param>
+        /// <param name="logger">An <see cref="ILogger"/> instance that can be used to log traces.</param>
+        public DbSession(IDbConnection connection, ILogger<IDbSession> logger)
         {
             _connection = connection;
+            _logger = logger;
         }
 
         /// <summary>Gets or sets the string used to open a database.</summary>
@@ -40,7 +53,10 @@ namespace Fg.DbUtils
         /// <summary>Opens a database connection with the settings specified by the ConnectionString property of the provider-specific Connection object.</summary>
         public void Open()
         {
-            _connection.Open();
+            if (_connection.State == ConnectionState.Closed)
+            {
+                _connection.Open();
+            }
         }
 
         /// <summary>Creates and returns a Command object associated with the connection.</summary>
@@ -146,5 +162,7 @@ namespace Fg.DbUtils
         /// <summary>Gets the name of the current database or the database to be used after a connection is opened.</summary>
         /// <returns>The name of the current database or the name of the database to be used once a connection is open. The default value is an empty string.</returns>
         string IDbConnection.Database => _connection.Database;
+
+        ILogger<IDbSession> IDbSession.Logger => _logger;
     }
 }

--- a/src/Fg.DbUtils/DbSession.cs
+++ b/src/Fg.DbUtils/DbSession.cs
@@ -124,7 +124,7 @@ namespace Fg.DbUtils
         /// <summary>Closes the connection to the database.</summary>
         public void Close()
         {
-            Transaction?.Rollback();
+            RollbackTransaction();
             _connection.Close();
 
             Transaction = null;

--- a/src/Fg.DbUtils/DbSession.cs
+++ b/src/Fg.DbUtils/DbSession.cs
@@ -65,7 +65,7 @@ namespace Fg.DbUtils
         public IDbCommand CreateCommand()
         {
             var command = _connection.CreateCommand();
-            if (IsInTransaction)
+            //if (IsInTransaction)
             {
                 command.Transaction = Transaction;
             }

--- a/src/Fg.DbUtils/DbSession.cs
+++ b/src/Fg.DbUtils/DbSession.cs
@@ -124,6 +124,12 @@ namespace Fg.DbUtils
                 {
                     _logger.LogDebug($"BeginTransaction: transaction is already active - NestedTransactionCount incremented ({_nestedTransactionCount})");
                 }
+
+                if (_nestedTransactionCount > 1)
+                {
+                    _logger.LogDebug("NestedTransaction > 1 - stacktrace: " + Environment.StackTrace);
+                }
+
                 return Transaction;
             }
 

--- a/src/Fg.DbUtils/DbSession.cs
+++ b/src/Fg.DbUtils/DbSession.cs
@@ -60,6 +60,8 @@ namespace Fg.DbUtils
             return BeginTransaction(IsolationLevel.ReadCommitted);
         }
 
+        private int _nestedTransactionCount = 0;
+
         /// <summary>Begins a database transaction with the specified <see cref="T:System.Data.IsolationLevel"></see> value.</summary>
         /// <param name="il">One of the <see cref="T:System.Data.IsolationLevel"></see> values.</param>
         /// <returns>An object representing the new transaction.</returns>
@@ -67,9 +69,10 @@ namespace Fg.DbUtils
         {
             if (IsInTransaction)
             {
+                _nestedTransactionCount++;
                 return Transaction;
             }
-            
+
             Transaction = _connection.BeginTransaction(il);
 
             return Transaction;
@@ -85,8 +88,15 @@ namespace Fg.DbUtils
                 return;
             }
 
-            Transaction?.Commit();
-            Transaction = null;
+            if (_nestedTransactionCount == 0)
+            {
+                Transaction?.Commit();
+                Transaction = null;
+            }
+            else
+            {
+                _nestedTransactionCount--;
+            }
         }
 
         /// <summary>

--- a/src/Fg.DbUtils/DbSession.cs
+++ b/src/Fg.DbUtils/DbSession.cs
@@ -86,6 +86,11 @@ namespace Fg.DbUtils
             {
                 _connection.Open();
             }
+
+            if (_nestedTransactionCount > 0)
+            {
+                _logger.LogDebug($"NestedTransactionCount > 0 when opening session ({_nestedTransactionCount})");
+            }
         }
 
         /// <summary>Creates and returns a Command object associated with the connection.</summary>
@@ -135,6 +140,11 @@ namespace Fg.DbUtils
 
             Transaction = _connection.BeginTransaction(isolationLevel);
 
+            if (_nestedTransactionCount != 0)
+            {
+                _logger.LogDebug($"NesteTransaction is {_nestedTransactionCount} on starting transaction");
+            }
+
             return Transaction;
         }
 
@@ -172,6 +182,7 @@ namespace Fg.DbUtils
         {
             if (IsInTransaction == false)
             {
+                _logger.LogDebug("Rollback is called while not in transaction");
                 return;
             }
 

--- a/src/Fg.DbUtils/DbSession.cs
+++ b/src/Fg.DbUtils/DbSession.cs
@@ -83,9 +83,9 @@ namespace Fg.DbUtils
         private int _nestedTransactionCount = 0;
 
         /// <summary>Begins a database transaction with the specified <see cref="T:System.Data.IsolationLevel"></see> value.</summary>
-        /// <param name="il">One of the <see cref="T:System.Data.IsolationLevel"></see> values.</param>
+        /// <param name="isolationLevel">One of the <see cref="T:System.Data.IsolationLevel"></see> values.</param>
         /// <returns>An object representing the new transaction.</returns>
-        public IDbTransaction BeginTransaction(IsolationLevel il)
+        public IDbTransaction BeginTransaction(IsolationLevel isolationLevel)
         {
             if (IsInTransaction)
             {
@@ -97,7 +97,7 @@ namespace Fg.DbUtils
                 return Transaction;
             }
 
-            Transaction = _connection.BeginTransaction(il);
+            Transaction = _connection.BeginTransaction(isolationLevel);
 
             return Transaction;
         }

--- a/src/Fg.DbUtils/DbSession.cs
+++ b/src/Fg.DbUtils/DbSession.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using System.Data;
-using System.Data.Common;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Fg.DbUtils

--- a/src/Fg.DbUtils/DbSession.cs
+++ b/src/Fg.DbUtils/DbSession.cs
@@ -114,7 +114,8 @@ namespace Fg.DbUtils
 
             if (_nestedTransactionCount == 0)
             {
-                Transaction?.Commit();
+                Transaction.Commit();
+                Transaction.Dispose();
                 Transaction = null;
                 _logger.LogDebug("CommitTransaction: transaction committed");
             }

--- a/src/Fg.DbUtils/DbSession.cs
+++ b/src/Fg.DbUtils/DbSession.cs
@@ -64,7 +64,10 @@ namespace Fg.DbUtils
         public IDbCommand CreateCommand()
         {
             var command = _connection.CreateCommand();
-            command.Transaction = Transaction;
+            if (IsInTransaction)
+            {
+                command.Transaction = Transaction;
+            }
 
             return command;
         }

--- a/src/Fg.DbUtils/DbSession.cs
+++ b/src/Fg.DbUtils/DbSession.cs
@@ -123,7 +123,7 @@ namespace Fg.DbUtils
                 _nestedTransactionCount++;
                 using (_logger.BeginScope(new Dictionary<string, object>() { ["NestedTransactionCount"] = _nestedTransactionCount }))
                 {
-                    _logger.LogDebug("BeginTransaction: transaction is already active - NestedTransactionCount incremented");
+                    _logger.LogDebug($"BeginTransaction: transaction is already active - NestedTransactionCount incremented ({_nestedTransactionCount})");
                 }
                 return Transaction;
             }
@@ -155,7 +155,7 @@ namespace Fg.DbUtils
                 _nestedTransactionCount--;
                 using (_logger.BeginScope(new Dictionary<string, object>() { ["NestedTransactionCount"] = _nestedTransactionCount }))
                 {
-                    _logger.LogDebug("CommitTransaction: nested transaction count decremented");
+                    _logger.LogDebug($"CommitTransaction: nested transaction count decremented ({_nestedTransactionCount})");
                 }
             }
         }
@@ -190,6 +190,7 @@ namespace Fg.DbUtils
             _connection.Close();
 
             Transaction = null;
+            _nestedTransactionCount = 0;
         }
 
         /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>

--- a/src/Fg.DbUtils/DbSession.cs
+++ b/src/Fg.DbUtils/DbSession.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using System.Data;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -24,6 +25,16 @@ namespace Fg.DbUtils
         /// <param name="logger">An <see cref="ILogger"/> instance that can be used to log traces.</param>
         public DbSession(IDbConnection connection, ILogger<IDbSession> logger)
         {
+            if (connection == null)
+            {
+                throw new ArgumentNullException(nameof(connection));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
             _connection = connection;
             _logger = logger;
         }

--- a/src/Fg.DbUtils/DbSessionFactory.cs
+++ b/src/Fg.DbUtils/DbSessionFactory.cs
@@ -1,20 +1,28 @@
 ﻿using System;
 using System.Data;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Fg.DbUtils
 {
     public class DbSessionFactory : IDbSessionFactory
     {
         private readonly Func<IDbConnection> _dbConnectionFactory;
+        private readonly Func<ILogger<IDbSession>> _loggerFactory;
 
-        public DbSessionFactory(Func<IDbConnection> dbConnectionFactory)
+        public DbSessionFactory(Func<IDbConnection> dbConnectionFactory) : this(dbConnectionFactory, () => NullLogger<IDbSession>.Instance)
+        {
+        }
+
+        public DbSessionFactory(Func<IDbConnection> dbConnectionFactory, Func<ILogger<IDbSession>> loggerFactory)
         {
             _dbConnectionFactory = dbConnectionFactory;
+            _loggerFactory = loggerFactory;
         }
 
         public IDbSession CreateDbSession()
         {
-            var session = new DbSession(_dbConnectionFactory());
+            var session = new DbSession(_dbConnectionFactory(), _loggerFactory());
 
             session.Open();
 

--- a/src/Fg.DbUtils/DbSessionFactory.cs
+++ b/src/Fg.DbUtils/DbSessionFactory.cs
@@ -22,11 +22,7 @@ namespace Fg.DbUtils
 
         public IDbSession CreateDbSession()
         {
-            var session = new DbSession(_dbConnectionFactory(), _loggerFactory());
-
-            session.Open();
-
-            return session;
+            return CreateDbSession(DbSessionSettings.Default);
         }
 
         public IDbSession CreateDbSession(DbSessionSettings settings)

--- a/src/Fg.DbUtils/DbSessionFactory.cs
+++ b/src/Fg.DbUtils/DbSessionFactory.cs
@@ -28,5 +28,14 @@ namespace Fg.DbUtils
 
             return session;
         }
+
+        public IDbSession CreateDbSession(DbSessionSettings settings)
+        {
+            var session = new DbSession(_dbConnectionFactory(), settings, _loggerFactory());
+
+            session.Open();
+
+            return session;
+        }
     }
 }

--- a/src/Fg.DbUtils/DbSessionSettings.cs
+++ b/src/Fg.DbUtils/DbSessionSettings.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Fg.DbUtils
+{
+    public class DbSessionSettings
+    {
+        public static readonly DbSessionSettings Default = new DbSessionSettings
+        {
+            CommandTimeout = TimeSpan.FromSeconds(30)
+        };
+
+        public TimeSpan CommandTimeout { get; set; } = TimeSpan.FromSeconds(30);
+    }
+}

--- a/src/Fg.DbUtils/Fg.DbUtils.csproj
+++ b/src/Fg.DbUtils/Fg.DbUtils.csproj
@@ -12,4 +12,8 @@
     <PackageTags>DbSession Dapper Transaction Connection IDbConnection IDbTransaction</PackageTags>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
+  </ItemGroup>
+
 </Project>

--- a/src/Fg.DbUtils/IDbSession.cs
+++ b/src/Fg.DbUtils/IDbSession.cs
@@ -1,4 +1,5 @@
 ﻿using System.Data;
+using Microsoft.Extensions.Logging;
 
 namespace Fg.DbUtils
 {
@@ -18,5 +19,11 @@ namespace Fg.DbUtils
         /// Rollbacks the active transaction of this IDbSession.
         /// </summary>
         void RollbackTransaction();
+
+        /// <summary>
+        /// Gets the logger that is used by this IDbSession.
+        /// </summary>
+        /// <remarks>This property is defined to have the possibility to call the Logger in extensions methods.</remarks>
+        ILogger<IDbSession> Logger { get; }
     }
 }

--- a/src/Fg.DbUtils/IDbSession.cs
+++ b/src/Fg.DbUtils/IDbSession.cs
@@ -1,9 +1,10 @@
-﻿using System.Data;
+﻿using System;
+using System.Data;
 using Microsoft.Extensions.Logging;
 
 namespace Fg.DbUtils
 {
-    public interface IDbSession : IDbConnection
+    public interface IDbSession : IDbConnection, IDisposable
     {
         /// <summary>
         /// Gets a value indicating whether the current IDbSession has an active transaction or not.

--- a/src/Fg.DbUtils/IDbSession.cs
+++ b/src/Fg.DbUtils/IDbSession.cs
@@ -1,10 +1,9 @@
-﻿using System;
+﻿using Microsoft.Extensions.Logging;
 using System.Data;
-using Microsoft.Extensions.Logging;
 
 namespace Fg.DbUtils
 {
-    public interface IDbSession : IDbConnection, IDisposable
+    public interface IDbSession : IDbConnection
     {
         /// <summary>
         /// Gets a value indicating whether the current IDbSession has an active transaction or not.

--- a/src/Fg.DbUtils/IDbSessionFactory.cs
+++ b/src/Fg.DbUtils/IDbSessionFactory.cs
@@ -7,5 +7,13 @@
         /// </summary>
         /// <returns>An <see cref="IDbSession"/></returns>
         IDbSession CreateDbSession();
+
+        /// <summary>
+        /// Create a new <see cref="IDbSession"/> instance
+        /// </summary>
+        /// <param name="settings">The <see cref="DbSessionSettings"/> instance that defines the settings that must
+        /// be applied to the <see cref="IDbSession"/> that is returned.</param>
+        /// <returns>An <see cref="IDbSession"/></returns>
+        IDbSession CreateDbSession(DbSessionSettings settings);
     }
 }

--- a/src/Fg.DbUtils/With.Transaction.cs
+++ b/src/Fg.DbUtils/With.Transaction.cs
@@ -34,7 +34,7 @@ namespace Fg.DbUtils
             }
             catch (Exception ex)
             {
-                session.Logger.LogError(ex, "An exception occurred while performing database-operations in a transaction.");
+                session.Logger?.LogError(ex, "An exception occurred while performing database-operations in a transaction.");
 
                 session.RollbackTransaction();
                 throw;
@@ -70,7 +70,7 @@ namespace Fg.DbUtils
             }
             catch (Exception ex)
             {
-                session.Logger.LogError(ex, "An exception occurred while performing database-operations in a transaction.");
+                session.Logger?.LogError(ex, "An exception occurred while performing database-operations in a transaction.");
 
                 session.RollbackTransaction();
                 throw;
@@ -139,7 +139,7 @@ namespace Fg.DbUtils
             }
             catch (Exception ex)
             {
-                session.Logger.LogError(ex, "An exception occurred while performing database-operations in a transaction.");
+                session.Logger?.LogError(ex, "An exception occurred while performing database-operations in a transaction.");
 
                 session.RollbackTransaction();
                 throw;

--- a/src/Fg.DbUtils/With.Transaction.cs
+++ b/src/Fg.DbUtils/With.Transaction.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Data;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace Fg.DbUtils
 {
@@ -37,8 +39,10 @@ namespace Fg.DbUtils
                     action();
                     session.CommitTransaction();
                 }
-                catch
+                catch(Exception ex)
                 {
+                    session.Logger.LogError(ex, "An exception occurred while performing database-operations in a transaction.");
+
                     session.RollbackTransaction();
                     throw;
                 }
@@ -161,8 +165,10 @@ namespace Fg.DbUtils
                     result = await action();
                     session.CommitTransaction();
                 }
-                catch
+                catch(Exception ex)
                 {
+                    session.Logger.LogError(ex, "An exception occurred while performing database-operations in a transaction.");
+
                     session.RollbackTransaction();
                     throw;
                 }

--- a/src/Fg.DbUtils/With.Transaction.cs
+++ b/src/Fg.DbUtils/With.Transaction.cs
@@ -1,8 +1,7 @@
-﻿using System;
+﻿using Microsoft.Extensions.Logging;
+using System;
 using System.Data;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 
 namespace Fg.DbUtils
 {
@@ -26,11 +25,11 @@ namespace Fg.DbUtils
         /// <param name="action"></param>
         public static void WithTransaction(this IDbSession session, IsolationLevel isolationLevel, Action action)
         {
-            if (session.IsInTransaction)
-            {
-                action();
-            }
-            else
+            //if (session.IsInTransaction)
+            //{
+            //    action();
+            //}
+            //else
             {
                 session.BeginTransaction(isolationLevel);
 
@@ -110,11 +109,11 @@ namespace Fg.DbUtils
         /// <param name="action"></param>
         public static async Task WithTransactionAsync(this IDbSession session, IsolationLevel isolationLevel, Func<Task> action)
         {
-            if (session.IsInTransaction)
-            {
-                await action();
-            }
-            else
+            //if (session.IsInTransaction)
+            //{
+            //    await action();
+            //}
+            //else
             {
                 session.BeginTransaction(isolationLevel);
 
@@ -149,12 +148,12 @@ namespace Fg.DbUtils
         /// <param name="action"></param>
         public static async Task<TResult> WithTransactionAsync<TResult>(this IDbSession session, IsolationLevel isolationLevel, Func<Task<TResult>> action)
         {
-            if (session.IsInTransaction)
-            {
-                var result = await action();
-                return result;
-            }
-            else
+            //if (session.IsInTransaction)
+            //{
+            //    var result = await action();
+            //    return result;
+            //}
+            //else
             {
                 TResult result;
 

--- a/src/Fg.DbUtils/With.Transaction.cs
+++ b/src/Fg.DbUtils/With.Transaction.cs
@@ -104,7 +104,7 @@ namespace Fg.DbUtils
             }
             catch (Exception ex)
             {
-                session.Logger.LogError(ex, "An exception occurred while performing database-operations in a transaction.");
+                session.Logger?.LogError(ex, "An exception occurred while performing database-operations in a transaction.");
 
                 session.RollbackTransaction();
                 throw;

--- a/src/Fg.DbUtils/With.Transaction.cs
+++ b/src/Fg.DbUtils/With.Transaction.cs
@@ -40,10 +40,10 @@ namespace Fg.DbUtils
                 }
                 catch (Exception ex)
                 {
+                    session.RollbackTransaction();
+
                     session.Logger?.LogError(ex,
                         "An exception occurred while performing database-operations in a transaction.");
-
-                    session.RollbackTransaction();
                     throw;
                 }
             }
@@ -84,10 +84,10 @@ namespace Fg.DbUtils
                 }
                 catch (Exception ex)
                 {
+                    session.RollbackTransaction();
+
                     session.Logger?.LogError(ex,
                         "An exception occurred while performing database-operations in a transaction.");
-
-                    session.RollbackTransaction();
                     throw;
                 }
             }
@@ -126,10 +126,10 @@ namespace Fg.DbUtils
                 }
                 catch (Exception ex)
                 {
+                    session.RollbackTransaction();
+
                     session.Logger?.LogError(ex,
                         "An exception occurred while performing database-operations in a transaction.");
-
-                    session.RollbackTransaction();
                     throw;
                 }
             }
@@ -169,10 +169,10 @@ namespace Fg.DbUtils
                 }
                 catch (Exception ex)
                 {
+                    session.RollbackTransaction();
+
                     session.Logger?.LogError(ex,
                         "An exception occurred while performing database-operations in a transaction.");
-
-                    session.RollbackTransaction();
                     throw;
                 }
             }

--- a/src/Fg.DbUtils/With.Transaction.cs
+++ b/src/Fg.DbUtils/With.Transaction.cs
@@ -59,22 +59,20 @@ namespace Fg.DbUtils
         /// <param name="action">The action that must be performed.</param>
         public static TResult WithTransaction<TResult>(this IDbSession session, IsolationLevel isolationLevel, Func<TResult> action)
         {
-            TResult result;
-
             session.BeginTransaction(isolationLevel);
 
             try
             {
-                result = action();
+                TResult result = action();
                 session.CommitTransaction();
+
+                return result;
             }
             catch
             {
                 session.RollbackTransaction();
                 throw;
             }
-
-            return result;
         }
 
         /// <summary>
@@ -127,14 +125,13 @@ namespace Fg.DbUtils
         /// <param name="action"></param>
         public static async Task<TResult> WithTransactionAsync<TResult>(this IDbSession session, IsolationLevel isolationLevel, Func<Task<TResult>> action)
         {
-            TResult result;
-
             session.BeginTransaction(isolationLevel);
 
             try
             {
-                result = await action();
+                TResult result = await action();
                 session.CommitTransaction();
+                return result;
             }
             catch (Exception ex)
             {
@@ -143,8 +140,6 @@ namespace Fg.DbUtils
                 session.RollbackTransaction();
                 throw;
             }
-
-            return result;
         }
     }
 }

--- a/src/Fg.DbUtils/With.Transaction.cs
+++ b/src/Fg.DbUtils/With.Transaction.cs
@@ -68,8 +68,10 @@ namespace Fg.DbUtils
 
                 return result;
             }
-            catch
+            catch (Exception ex)
             {
+                session.Logger.LogError(ex, "An exception occurred while performing database-operations in a transaction.");
+
                 session.RollbackTransaction();
                 throw;
             }
@@ -100,8 +102,10 @@ namespace Fg.DbUtils
                 await action();
                 session.CommitTransaction();
             }
-            catch
+            catch (Exception ex)
             {
+                session.Logger.LogError(ex, "An exception occurred while performing database-operations in a transaction.");
+
                 session.RollbackTransaction();
                 throw;
             }

--- a/src/Fg.DbUtils/With.Transaction.cs
+++ b/src/Fg.DbUtils/With.Transaction.cs
@@ -59,29 +59,22 @@ namespace Fg.DbUtils
         /// <param name="action">The action that must be performed.</param>
         public static TResult WithTransaction<TResult>(this IDbSession session, IsolationLevel isolationLevel, Func<TResult> action)
         {
-            if (session.IsInTransaction)
+            TResult result;
+
+            session.BeginTransaction(isolationLevel);
+
+            try
             {
-                return action();
+                result = action();
+                session.CommitTransaction();
             }
-            else
+            catch
             {
-                TResult result;
-
-                session.BeginTransaction(isolationLevel);
-
-                try
-                {
-                    result = action();
-                    session.CommitTransaction();
-                }
-                catch
-                {
-                    session.RollbackTransaction();
-                    throw;
-                }
-
-                return result;
+                session.RollbackTransaction();
+                throw;
             }
+
+            return result;
         }
 
         /// <summary>

--- a/src/Fg.DbUtils/With.Transaction.cs
+++ b/src/Fg.DbUtils/With.Transaction.cs
@@ -25,19 +25,27 @@ namespace Fg.DbUtils
         /// <param name="action"></param>
         public static void WithTransaction(this IDbSession session, IsolationLevel isolationLevel, Action action)
         {
-            session.BeginTransaction(isolationLevel);
-
-            try
+            if (session.IsInTransaction)
             {
                 action();
-                session.CommitTransaction();
             }
-            catch (Exception ex)
+            else
             {
-                session.Logger?.LogError(ex, "An exception occurred while performing database-operations in a transaction.");
+                session.BeginTransaction(isolationLevel);
 
-                session.RollbackTransaction();
-                throw;
+                try
+                {
+                    action();
+                    session.CommitTransaction();
+                }
+                catch (Exception ex)
+                {
+                    session.Logger?.LogError(ex,
+                        "An exception occurred while performing database-operations in a transaction.");
+
+                    session.RollbackTransaction();
+                    throw;
+                }
             }
         }
 
@@ -59,21 +67,29 @@ namespace Fg.DbUtils
         /// <param name="action">The action that must be performed.</param>
         public static TResult WithTransaction<TResult>(this IDbSession session, IsolationLevel isolationLevel, Func<TResult> action)
         {
-            session.BeginTransaction(isolationLevel);
-
-            try
+            if (session.IsInTransaction)
             {
-                TResult result = action();
-                session.CommitTransaction();
-
-                return result;
+                return action();
             }
-            catch (Exception ex)
+            else
             {
-                session.Logger?.LogError(ex, "An exception occurred while performing database-operations in a transaction.");
+                session.BeginTransaction(isolationLevel);
 
-                session.RollbackTransaction();
-                throw;
+                try
+                {
+                    TResult result = action();
+                    session.CommitTransaction();
+
+                    return result;
+                }
+                catch (Exception ex)
+                {
+                    session.Logger?.LogError(ex,
+                        "An exception occurred while performing database-operations in a transaction.");
+
+                    session.RollbackTransaction();
+                    throw;
+                }
             }
         }
 
@@ -95,19 +111,27 @@ namespace Fg.DbUtils
         /// <param name="action"></param>
         public static async Task WithTransactionAsync(this IDbSession session, IsolationLevel isolationLevel, Func<Task> action)
         {
-            session.BeginTransaction(isolationLevel);
-
-            try
+            if (session.IsInTransaction)
             {
                 await action();
-                session.CommitTransaction();
             }
-            catch (Exception ex)
+            else
             {
-                session.Logger?.LogError(ex, "An exception occurred while performing database-operations in a transaction.");
+                session.BeginTransaction(isolationLevel);
 
-                session.RollbackTransaction();
-                throw;
+                try
+                {
+                    await action();
+                    session.CommitTransaction();
+                }
+                catch (Exception ex)
+                {
+                    session.Logger?.LogError(ex,
+                        "An exception occurred while performing database-operations in a transaction.");
+
+                    session.RollbackTransaction();
+                    throw;
+                }
             }
         }
 
@@ -129,20 +153,28 @@ namespace Fg.DbUtils
         /// <param name="action"></param>
         public static async Task<TResult> WithTransactionAsync<TResult>(this IDbSession session, IsolationLevel isolationLevel, Func<Task<TResult>> action)
         {
-            session.BeginTransaction(isolationLevel);
-
-            try
+            if (session.IsInTransaction)
             {
-                TResult result = await action();
-                session.CommitTransaction();
-                return result;
+                return (await action());
             }
-            catch (Exception ex)
+            else
             {
-                session.Logger?.LogError(ex, "An exception occurred while performing database-operations in a transaction.");
+                session.BeginTransaction(isolationLevel);
 
-                session.RollbackTransaction();
-                throw;
+                try
+                {
+                    TResult result = await action();
+                    session.CommitTransaction();
+                    return result;
+                }
+                catch (Exception ex)
+                {
+                    session.Logger?.LogError(ex,
+                        "An exception occurred while performing database-operations in a transaction.");
+
+                    session.RollbackTransaction();
+                    throw;
+                }
             }
         }
     }


### PR DESCRIPTION
The way nested transactions where handled when using WithTransaction should now be better.
Next to that, it is now also possible to pass in an ILogger into the DbSession