### PR TITLE
DbSessionSettings are instantiated via a Factory Method

### DIFF
--- a/src/Fg.DbUtils/DbSessionSettings.cs
+++ b/src/Fg.DbUtils/DbSessionSettings.cs
@@ -4,11 +4,16 @@ namespace Fg.DbUtils
 {
     public class DbSessionSettings
     {
-        public static readonly DbSessionSettings Default = new DbSessionSettings
-        {
-            CommandTimeout = TimeSpan.FromSeconds(30)
-        };
+        public static readonly DbSessionSettings Default = DbSessionSettings.Create(TimeSpan.FromSeconds(30));
 
-        public TimeSpan CommandTimeout { get; set; } = TimeSpan.FromSeconds(30);
+        public static DbSessionSettings Create(TimeSpan commandTimeout)
+        {
+            return new DbSessionSettings()
+            {
+                CommandTimeout = commandTimeout
+            };
+        }
+
+        public TimeSpan CommandTimeout { get; private set; } = TimeSpan.FromSeconds(30);
     }
 }


### PR DESCRIPTION
The DbSessionSettings type is now defined as an immutable class.
Instantiation is done via a factory method.