### PR TITLE
[feat] Functionality for registering post-transaction commands

### DIFF
--- a/src/Fg.DbUtils.Dapper.IntegrationTests/DbSessionTransactionTests.cs
+++ b/src/Fg.DbUtils.Dapper.IntegrationTests/DbSessionTransactionTests.cs
@@ -5,14 +5,14 @@ using Xunit;
 
 namespace Fg.DbUtils.Dapper.IntegrationTests
 {
-    public class DapperTransactionTests : IDisposable
+    public class DbSessionTransactionTests : IDisposable
     {
         private readonly SQLiteConnection _connection;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DapperTransactionTests"/> class.
+        /// Initializes a new instance of the <see cref="DbSessionTransactionTests"/> class.
         /// </summary>
-        public DapperTransactionTests()
+        public DbSessionTransactionTests()
         {
             _connection = SqliteDatabase.OpenDatabase();
         }
@@ -81,6 +81,22 @@ namespace Fg.DbUtils.Dapper.IntegrationTests
             dbSession.BeginTransaction();
 
             Assert.Throws<InvalidOperationException>(() => dbSession.BeginTransaction());
+        }
+
+        [Fact]
+        public void CommitTransaction_Executes_RegisteredPostTransactionActions()
+        {
+            var dbSession = new DbSession(_connection);
+
+            dbSession.BeginTransaction();
+
+            bool postTransactionExecuted = false;
+
+            dbSession.RegisterPostTransactionAction(() => postTransactionExecuted = true);
+
+            dbSession.CommitTransaction();
+
+            Assert.True(postTransactionExecuted);
         }
 
         /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>

--- a/src/Fg.DbUtils.Dapper.IntegrationTests/DbSessionTransactionTests.cs
+++ b/src/Fg.DbUtils.Dapper.IntegrationTests/DbSessionTransactionTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Data.SQLite;
 using Dapper;
+using Microsoft.VisualStudio.TestPlatform.Common.Telemetry;
 using Xunit;
 
 namespace Fg.DbUtils.Dapper.IntegrationTests
@@ -97,6 +98,16 @@ namespace Fg.DbUtils.Dapper.IntegrationTests
             dbSession.CommitTransaction();
 
             Assert.True(postTransactionExecuted);
+        }
+
+        [Fact]
+        public void RegisterPostTransaction_Throws_WhenNoTransactionIsActive()
+        {
+            var dbSession = new DbSession(_connection);
+
+            Assert.False(dbSession.IsInTransaction);
+
+            Assert.Throws<InvalidOperationException>(() => dbSession.RegisterPostTransactionAction(() => Console.WriteLine("No Operation") ));
         }
 
         /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>

--- a/src/Fg.DbUtils/DbSession.cs
+++ b/src/Fg.DbUtils/DbSession.cs
@@ -181,8 +181,19 @@ namespace Fg.DbUtils
 
         private readonly Queue<Action> _postTransactionActions = new Queue<Action>();
 
+        /// <summary>
+        /// Registers an <see cref="Action"/> that must be executed right after the current Transaction is committed.
+        /// </summary>
+        /// <remarks>The registered actions are executed in a 'fire and forget' manner.  If an action contains async code, the action is not awaited.</remarks>
+        /// <param name="action"></param>
+        /// <exception cref="InvalidOperationException">Thrown when the DbSession is currently not in a transaction.</exception>
         public void RegisterPostTransactionAction(Action action)
         {
+            if (IsInTransaction)
+            {
+                throw new InvalidOperationException("Unable to register a PostTransactionAction as the DbSession is currently not in a transaction");
+            }
+
             _postTransactionActions.Enqueue(action);
         }
 

--- a/src/Fg.DbUtils/DbSession.cs
+++ b/src/Fg.DbUtils/DbSession.cs
@@ -173,7 +173,7 @@ namespace Fg.DbUtils
             Transaction?.Rollback();
             Transaction?.Dispose();
             Transaction = null;
-            
+
             _logger.LogDebug("Transaction rollbacked on DbSession with Id {DbSessionId}", _sessionId);
 
             _postTransactionActions.Clear();
@@ -189,7 +189,7 @@ namespace Fg.DbUtils
         /// <exception cref="InvalidOperationException">Thrown when the DbSession is currently not in a transaction.</exception>
         public void RegisterPostTransactionAction(Action action)
         {
-            if (IsInTransaction)
+            if (IsInTransaction == false)
             {
                 throw new InvalidOperationException("Unable to register a PostTransactionAction as the DbSession is currently not in a transaction");
             }

--- a/src/Fg.DbUtils/DbSession.cs
+++ b/src/Fg.DbUtils/DbSession.cs
@@ -173,7 +173,10 @@ namespace Fg.DbUtils
             Transaction?.Rollback();
             Transaction?.Dispose();
             Transaction = null;
+            
             _logger.LogDebug("Transaction rollbacked on DbSession with Id {DbSessionId}", _sessionId);
+
+            _postTransactionActions.Clear();
         }
 
         private readonly Queue<Action> _postTransactionActions = new Queue<Action>();

--- a/src/Fg.DbUtils/IDbSession.cs
+++ b/src/Fg.DbUtils/IDbSession.cs
@@ -27,9 +27,10 @@ namespace Fg.DbUtils
         void RollbackTransaction();
 
         /// <summary>
-        /// 
+        /// Register an <see cref="Action"/> that must be executed after the current Transaction is committed.
         /// </summary>
-        /// <param name="action"></param>
+        /// <remarks>Multiple actions can be registered; the action that was registered first, will be executed first.</remarks>
+        /// <param name="action">The action that must be executed.</param>
         void RegisterPostTransactionAction(Action action);
 
         /// <summary>

--- a/src/Fg.DbUtils/IDbSession.cs
+++ b/src/Fg.DbUtils/IDbSession.cs
@@ -27,6 +27,12 @@ namespace Fg.DbUtils
         void RollbackTransaction();
 
         /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="action"></param>
+        void RegisterPostTransactionAction(Action action);
+
+        /// <summary>
         /// Gets the logger that is used by this IDbSession.
         /// </summary>
         /// <remarks>This property is defined to have the possibility to call the Logger in extensions methods.</remarks>


### PR DESCRIPTION
This feature allows you to register some action while performing the transaction, but defer the execution of that action until after the transaction has been committed.