### PR TITLE
All traces should be logged at debug level

### DIFF
--- a/src/Fg.DbUtils/With.Transaction.cs
+++ b/src/Fg.DbUtils/With.Transaction.cs
@@ -42,7 +42,7 @@ namespace Fg.DbUtils
                 {
                     session.RollbackTransaction();
 
-                    session.Logger?.LogError(ex,
+                    session.Logger?.LogDebug(ex,
                         "An exception occurred while performing database-operations in a transaction on DbSession with Id  {DbSessionId}", session.SessionId);
                     throw;
                 }
@@ -86,7 +86,7 @@ namespace Fg.DbUtils
                 {
                     session.RollbackTransaction();
 
-                    session.Logger?.LogError(ex,
+                    session.Logger?.LogDebug(ex,
                         "An exception occurred while performing database-operations in a transaction on DbSession with Id  {DbSessionId}", session.SessionId);
                     throw;
                 }
@@ -128,7 +128,7 @@ namespace Fg.DbUtils
                 {
                     session.RollbackTransaction();
 
-                    session.Logger?.LogError(ex,
+                    session.Logger?.LogDebug(ex,
                         "An exception occurred while performing database-operations in a transaction on DbSession with Id  {DbSessionId}", session.SessionId);
                     throw;
                 }
@@ -171,7 +171,7 @@ namespace Fg.DbUtils
                 {
                     session.RollbackTransaction();
 
-                    session.Logger?.LogError(ex,
+                    session.Logger?.LogDebug(ex,
                         "An exception occurred while performing database-operations in a transaction on DbSession with Id  {DbSessionId}", session.SessionId);
                     throw;
                 }


### PR DESCRIPTION
To avoid bloated logging in software that uses this library, all traces are now logged with a Debug trace-level.
This allows for easy filtering which traces should be logged and which not.